### PR TITLE
SOPS-5: Add GitHub Actions publish pipeline and bump version to 0.9.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm ci
+      - run: npm run compile
+      - run: npm run lint
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm ci
+      - name: Publish to VS Code Marketplace
+        run: npx vsce publish -p ${{ secrets.VSCE_PAT }}
+      - name: Publish to Open VSX
+        run: npx ovsx publish -p ${{ secrets.OVSX_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the "vscode-sops" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.9.5]
+### Added
+- GitHub Actions CI/CD pipeline: automatic publish to VS Code Marketplace and Open VSX on merge to master.
+
+### Changed
+- Removed custom `maxBuffer` override from SOPS spawn options (reverted to Node.js default).
+
+## [0.9.4]
+### Changed
+- Internal improvements and dependency updates.
+
 ## [0.9.3]
 ### Fixed
 - Missing `--mac-only-encrypted` option in `sops` command.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "s2504s-vscode-sops",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "s2504s-vscode-sops",
-			"version": "0.9.4",
+			"version": "0.9.5",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "@s2504s/vscode-sops",
 	"description": "",
 	"publisher": "s2504s",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/serhii-ciq/vscode-sops"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,6 @@ const isEnabled = (context: vscode.ExtensionContext) => {
 };
 let spawnOptions: child_process.SpawnSyncOptions = {
 	cwd: process.env.HOME,
-	maxBuffer: 20 * 1024 * 1024, // 20 MB
 	timeout: 2_000, // 2 seconds — kill SOPS if it hangs (e.g. invalid file in editor mode)
 };
 


### PR DESCRIPTION
## Summary

Add CI/CD pipeline that automatically publishes the extension to both VS Code Marketplace and Open VSX Registry on merge to `master`.

## Changes

- **`.github/workflows/publish.yml`** — new GitHub Actions workflow:
  - `build` job: checkout → install → compile → lint
  - `publish` job (depends on build): publish to VS Code Marketplace (`VSCE_PAT`) and Open VSX (`OVSX_TOKEN`)
  - Triggered only on push to `master` (no PR builds)
- **`src/extension.ts`** — removed custom `maxBuffer: 20 MB` override from SOPS spawn options (reverted to Node.js default)
- **`package.json`** — version bump `0.9.4` → `0.9.5`
- **`CHANGELOG.md`** — added entries for `0.9.4` and `0.9.5`

## Required Secrets

Make sure the following GitHub repository secrets are configured:
- `VSCE_PAT` — VS Code Marketplace personal access token
- `OVSX_TOKEN` — Open VSX Registry access token

Closes #5